### PR TITLE
cannot work when installed because of webpack sources version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 yarn.lock
 *.js.map
 /node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ module.exports = {
 };
 ```
 
+### Test
+1. `git clone`
+2. `npm install`
+3. `npm test`
+4. open `dist/bundle.js` to check your upgraded code.
+
 ### API
 #### EditableSourcesWebpackPlugin
 Type: `constructor`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "editable-sources-webpack-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
+  "scripts": {
+    "test": "webpack"
+  },
   "description": "Edit any sources during bundling with webpack",
   "keywords": [
     "webpack",
@@ -22,6 +25,9 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "multi-stage-sourcemap": "^0.2.1"
+    "webpack-sources": "1.0.1",
+    "multi-stage-sourcemap": "^0.2.1",
+    "webpack": "^4.2.0",
+    "webpack-cli": "^2.0.13"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+console.log('hello world!');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const webpack = require('webpack'); //访问内置的插件
+const EditableSourcesWebpackPlugin = require('./index');
+
+module.exports = {
+    mode: 'development',
+    entry: './test.js',
+    devtool: 'source-map',
+    plugins: [
+        new CleanWebpackPlugin(['dist']),
+        new EditableSourcesWebpackPlugin(/\.js$/, function (sourceCode) {
+            return `// ******** hello world! This is the embeded comment ********
+                ${sourceCode}
+            // ******** embeded comment end *******`;
+        })
+    ],
+    output: {
+        filename: 'bundle.js',
+        path: path.resolve(__dirname, 'dist')
+    }
+  };


### PR DESCRIPTION
fixed this error.
```
(node:23907) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
/Users/zhaotai/Workspace/def_plugin/node_modules/_source-map@0.6.1@source-map/lib/source-map-generator.js:276
        throw new Error(
        ^

Error: original.line and original.column are not numbers -- you probably meant to omit the original mapping entirely and only map the generated position. If so, pass null for the originalmapping instead of an object with empty or null values.
    at SourceMapGenerator_validateMapping [as _validateMapping] (/Users/zhaotai/Workspace/def_plugin/node_modules/_source-map@0.6.1@source-map/lib/source-map-generator.js:276:15)
    at SourceMapGenerator_addMapping [as addMapping] (/Users/zhaotai/Workspace/def_plugin/node_modules/_source-map@0.6.1@source-map/lib/source-map-generator.js:110:12)
    at /Users/zhaotai/Workspace/def_plugin/node_modules/_source-map@0.6.1@source-map/lib/source-map-generator.js:72:17
    at Array.forEach (native)
    at SourceMapConsumer_eachMapping [as eachMapping] (/Users/zhaotai/Workspace/def_plugin/node_modules/_source-map@0.6.1@source-map/lib/source-map-consumer.js:157:14)
    at Function.SourceMapGenerator_fromSourceMap [as fromSourceMap] (/Users/zhaotai/Workspace/def_plugin/node_modules/_source-map@0.6.1@source-map/lib/source-map-generator.js:48:24)
    at SourceMapSource.node (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack-sources@1.1.0@webpack-sources/lib/SourceMapSource.js:32:35)
    at SourceMapSource.proto.sourceAndMap (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack-sources@1.1.0@webpack-sources/lib/SourceAndMapMixin.js:30:18)
    at getTaskForFile (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/SourceMapDevToolPlugin.js:34:30)
    at files.forEach (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/SourceMapDevToolPlugin.js:127:20)
    at Array.forEach (native)
    at compilation.hooks.afterOptimizeChunkAssets.tap (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/SourceMapDevToolPlugin.js:121:12)
    at SyncHook.eval (eval at create (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/HookCodeFactory.js:17:12), <anonymous>:7:1)
    at SyncHook.lazyCompileHook [as _call] (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/Hook.js:35:21)
    at hooks.optimizeChunkAssets.callAsync.err (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/Compilation.js:947:42)
    at _err0 (eval at create (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/HookCodeFactory.js:24:12), <anonymous>:11:1)
    at compilation.plugin (/Users/zhaotai/Workspace/def_plugin/node_modules/_editable-sources-webpack-plugin@1.0.1@editable-sources-webpack-plugin/index.js:87:17)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/HookCodeFactory.js:24:12), <anonymous>:7:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/Hook.js:35:21)
    at hooks.additionalAssets.callAsync.err (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/Compilation.js:943:36)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/HookCodeFactory.js:24:12), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/Hook.js:35:21)
    at hooks.optimizeTree.callAsync.err (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/Compilation.js:939:32)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/HookCodeFactory.js:24:12), <anonymous>:6:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/Hook.js:35:21)
    at Compilation.seal (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/Compilation.js:881:27)
    at hooks.make.callAsync.err (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/Compiler.js:480:17)
    at _err0 (eval at create (/Users/zhaotai/Workspace/def_plugin/node_modules/_tapable@1.0.0@tapable/lib/HookCodeFactory.js:24:12), <anonymous>:11:1)
    at _addModuleChain (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/Compilation.js:749:12)
    at processModuleDependencies.err (/Users/zhaotai/Workspace/def_plugin/node_modules/_webpack@4.2.0@webpack/lib/Compilation.js:688:9)
```